### PR TITLE
[IMP] partner_credit_limit: ignore on SO

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Partner Credit Limit',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.1.0',
     'category': 'Partner',
     'depends': ['account', 'sale'],
     'license': 'AGPL-3',
@@ -18,6 +18,7 @@
     'website': 'http://www.serpentcs.com',
     'data': [
         'views/partner_view.xml',
+        'views/sale_order_views.xml',
     ],
     'installable': True,
     'auto_install': False,

--- a/partner_credit_limit/models/sale.py
+++ b/partner_credit_limit/models/sale.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Serpent Consulting Services Pvt. Ltd.
 # See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, _
+from odoo import fields, models, api, _
 from datetime import datetime
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
 from odoo.exceptions import UserError
@@ -10,6 +10,8 @@ from odoo.exceptions import UserError
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    over_credit = fields.Boolean("Allow Over Credit?")
 
     @api.multi
     def check_limit(self):
@@ -31,7 +33,7 @@ class SaleOrder(models.Model):
                 debit += line.credit
 
         if (credit - debit + self.amount_total) > partner.credit_limit:
-            if not partner.over_credit:
+            if not partner.over_credit and not self.over_credit:
                 msg = 'Can not confirm Sale Order,Total mature due Amount ' \
                       '%s as on %s !\nCheck Partner Accounts or Credit ' \
                       'Limits !' % (credit - debit, today_dt)

--- a/partner_credit_limit/views/sale_order_views.xml
+++ b/partner_credit_limit/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.over.credit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <group name="sale_pay" position="inside">
+                <field name="over_credit" attrs="{'readonly': [('state', 'not in', ('draft', 'sent'))]}"/>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
WE can now ignore credit limit on specific SO without enabling ignore
for partner on all sale orders. This has better flexibility.